### PR TITLE
moved --log-level to the end of final_cmd of the node process 

### DIFF
--- a/better_launch/elements/node.py
+++ b/better_launch/elements/node.py
@@ -164,9 +164,6 @@ class Node(AbstractNode, LiveParamsMixin):
                 final_cmd.extend(self.cmd_args)
 
             if not self.raw:
-                if self.node_log_level is not None:
-                    final_cmd += ["--log-level", self.node_log_level]
-
                 final_cmd += ["--ros-args"]
 
                 # Attach node parameters
@@ -179,6 +176,9 @@ class Node(AbstractNode, LiveParamsMixin):
                 for src, dst in self._ros_args().items():
                     # launch_ros/actions/node.py:481
                     final_cmd.extend(["-r", f"{src}:={dst}"])
+
+                if self.node_log_level is not None:
+                    final_cmd += ["--log-level", self.node_log_level]
 
             # If an env is specified ROS2 lets it completely replace the host env. We cover this
             # through an additional flag, as often you just want to make certain overrides.


### PR DESCRIPTION
Related issue: https://github.com/dfki-ric/better_launch/issues/3

I moved the `--log-level` launch arg at the end of the node executable command in order to make the `static_transform_publisher` work with `better_launch`. I ran a couple of the `better_launch` examples and it worked fine. Not sure, if there are any downsides in moving it at the end of the command