### PR TITLE
Add rosdep keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,16 +367,17 @@ pip install wonderwords
 <details>
     <summary>System</summary>
 
-If you don't want to setup a *venv* you can install the dependencies as system packages. This can be done as follows:
+If you don't want to setup a *venv* you can install the dependencies as system packages. This can be done with rosdep:
 
 ```bash
-# The package names will likely be different on non-Ubuntu systems
 sudo apt update
-sudo apt install python3-pip python3-click python3-yaml python3-setproctitle python3-psutil python3-prompt-toolkit python3-osrf-pycommon python3-psutil
+rosdep update
+rosdep install --from-paths src --ignore-src -y
+```
 
-# Install any dependencies not offered by your package manager via pip
-sudo pip install --break-system-packages docstring_parser
+You can also install an optional dependency via pip:
 
+```bash
 # Optional, used for anonymous node names
 sudo pip install --break-system-packages wonderwords
 ```

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="2">
   <name>better_launch</name>
   <version>1.0.2</version>
-  
+
   <description>
     A better replacement for the ROS2 launch system: intuitive, simple, memorable.
   </description>
@@ -10,10 +10,10 @@
   <url type="website">https://dfki-ric.github.io/better_launch/</url>
   <url type="repository">https://github.com/dfki-ric/better_launch</url>
   <url type="bugtracker">https://github.com/dfki-ric/better_launch/issues</url>
-  
+
   <author email="nikolas.dahn@gmail.com">Nikolas Dahn</author>
   <maintainer email="nikolas.dahn@gmail.com">Nikolas Dahn</maintainer>
-  
+
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake_python</buildtool_depend>
@@ -24,6 +24,13 @@
   <depend>lifecycle_msgs</depend>
   <depend>composition_interfaces</depend>
   <depend>rclpy</depend>
+  <depend>python3-click</depend>
+  <depend>python3-yaml</depend>
+  <depend>python3-setproctitle</depend>
+  <depend>python3-psutil</depend>
+  <depend>python3-prompt-toolkit</depend>
+  <depend>python3-osrf-pycommon</depend>
+  <depend>python3-docstring-parser</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Add rosdep keys for easier installation of dependencies. wonderwords is not in rosdistro, but if it's really needed it could be added.