### PR TITLE
fix: missing third capture group

### DIFF
--- a/better_launch/gazebo.py
+++ b/better_launch/gazebo.py
@@ -574,7 +574,7 @@ class GazeboBridge:
         ValueError
             If the bridge string doesn't match the expected pattern.
         """
-        m = re.match(r"(.+)@(.+)[\[\]@](.+)", bridge)
+        m = re.match(r"(.+)@(.+)([\[\]@])(.+)", bridge)
 
         if not m:
             raise ValueError(bridge + " is not a valid bridge string")


### PR DESCRIPTION
Very simple patch for broken regex match in GazeboBridge from_string method. The third capture group was missing causing an IndexError to be thrown.