### PR TITLE
Add ament_cmake_python package requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(better_launch)
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 
 # Run via `colcon test --packages-select better_launch`. 
 # Examine results with `colcon test-result --all`


### PR DESCRIPTION
Currently the `CMakeLists.txt` is missing the `ament_cmake_python` requirement, resulting in a broken package if we build it for "binary" distribution via e.g. robostack/pixi. This PR adds this requirement, which is present in most CMake based ROS2 Python packages. The `package.xml` already contains this dependency.