### PR TITLE
Enable explicit node parameter overrides for bl launches

### DIFF
--- a/better_launch/declarative/declarative.py
+++ b/better_launch/declarative/declarative.py
@@ -140,6 +140,7 @@ def _get_toml_args(toml: dict) -> list[DeclaredArg]:
 def launch_toml(
     path: str,
     launch_args: dict[str, str] = None,
+    extra_args: list[str] = None,
     eval_mode: Literal["full", "literal", "none"] = None,
     *,
     ui: bool = None,
@@ -190,7 +191,7 @@ def launch_toml(
         package = "composition"
         plugin = "composition::Talker"
 
-    In addition, any call table may contain an `if` and `unless` attribute to tie execution to a condition (which of course may contain substitutions). These will be evaluated according to 
+    In addition, any call table may contain an `if` and `unless` attribute to tie execution to a condition (which of course may contain substitutions). These will be evaluated according to
     python truthiness.
     - if     -> execute only if condition is true
     - unless -> execute only if condition is false
@@ -213,6 +214,8 @@ def launch_toml(
         Path to the TOML launchfile to execute.
     launch_args : dict[str, str], optional
         values for launch arguments declared by the launchfile.
+    extra_args : list[str], optional
+        Extra CLI arguments to pass through (e.g. node parameter overrides).
     eval_mode : Literal[&quot;full&quot;, &quot;literal&quot;, &quot;none&quot;], optional
         How to treat `eval` substitutions.
     ui : bool, optional
@@ -248,7 +251,7 @@ def launch_toml(
 
     if toml_format == current_toml_format_version:
         pass
-    #elif toml_format == some_previous_version: ...
+    # elif toml_format == some_previous_version: ...
 
     # TODO establish and verify argument precedence:
     # CLI > env > launchfile > default
@@ -286,6 +289,11 @@ def launch_toml(
         for key, arg in launch_args.items():
             if arg is not None:
                 argv.extend([f"--{key}", arg])
+
+    if extra_args:
+        if argv is None:
+            argv = []
+        argv.extend(extra_args)
 
     def launch_func(*args, **kwargs):
         toml.update(kwargs)

--- a/better_launch/launcher.py
+++ b/better_launch/launcher.py
@@ -117,6 +117,7 @@ class BetterLaunch(metaclass=_BetterLaunchMeta):
 
     _launchfile: str = None
     _launch_func_args: dict[str, Any] = {}
+    _node_param_overrides: dict[str, dict[str, Any]] = {}
 
     def __init__(
         self,
@@ -214,6 +215,10 @@ Takeoff in 3... 2... 1...
         print(msg)
         self.logger.critical(f"Log files at {roslog.launch_config.log_dir}")
 
+    def set_node_param_overrides(self, overrides: dict[str, dict[str, Any]]) -> None:
+        """Set node parameter overrides from CLI."""
+        self._node_param_overrides = overrides
+
     def spin(self, exit_with_last_node: bool = True) -> None:
         """Join the BetterLaunch thread until it terminates. You do **not** need to call this if you're using the :py:meth:`launch_this` wrapper or the TUI.
 
@@ -243,7 +248,9 @@ Takeoff in 3... 2... 1...
             except (CancelledError, TimeoutError):
                 pass
 
-        self.logger.critical(f"Reminder: log files are at {roslog.launch_config.log_dir}")
+        self.logger.critical(
+            f"Reminder: log files are at {roslog.launch_config.log_dir}"
+        )
 
     def get_unique_name(self, name: str = "", check_running_nodes: bool = True) -> str:
         """Returns a unique name. If a name is provided it will be prepended with an underscore.
@@ -336,10 +343,10 @@ Takeoff in 3... 2... 1...
             nodes.append(self._ros2_launcher)
 
         if include_foreign:
-            # Note that self.shared_node.get_node_names_and_namespaces() will only give us the 
+            # Note that self.shared_node.get_node_names_and_namespaces() will only give us the
             # names and namespaces, but no handle on the actual processes, not even a package
 
-            # TODO should check if it's a composer and has subnodes, but we won't know the 
+            # TODO should check if it's a composer and has subnodes, but we won't know the
             # components' handles or plugins...
             # if include_components:
             #     for f in foreign:
@@ -347,7 +354,7 @@ Takeoff in 3... 2... 1...
             #             composer = Composer(f)
             #             for cid, component in composer.get_live_components().items():
             #                 nodes.append(Component(...))
-            
+
             foreign = self.get_foreign_nodes()
             nodes.extend(foreign)
 
@@ -667,9 +674,7 @@ Takeoff in 3... 2... 1...
             If `package` contains path separators, or if a `filename` is provided but could not be found within base path.
         """
         if filename and os.path.isabs(filename):
-            self.logger.info(
-                f"find({package}, {filename}, {subdir}):1 -> {filename}"
-            )
+            self.logger.info(f"find({package}, {filename}, {subdir}):1 -> {filename}")
             return filename
 
         if not package:
@@ -717,7 +722,6 @@ Takeoff in 3... 2... 1...
         raise ValueError(
             f"Could not find file or directory (package={package}, filename={filename}, subdir={subdir}), searched path was {base_path}"
         )
-
 
     def load_params(
         self,
@@ -1468,13 +1472,24 @@ Takeoff in 3... 2... 1...
         group = self.group_tip
         namespace = group.assemble_namespace()
 
+        # Merge CLI overrides (CLI takes precedence)
+        resolved_params = params
+        if isinstance(params, str):
+            resolved_params = self.load_params(configfile=params)
+        elif params is None:
+            resolved_params = {}
+
+        cli_overrides = self._node_param_overrides.get(name, {})
+        if cli_overrides:
+            resolved_params = {**resolved_params, **cli_overrides}
+
         node = Node(
             package,
             executable,
             name,
             namespace,
             remaps=remaps,
-            params=params,
+            params=resolved_params,
             cmd_args=cmd_args,
             env=env,
             isolate_env=isolate_env,
@@ -1637,7 +1652,14 @@ Takeoff in 3... 2... 1...
             else:
                 raise ValueError(f"Unknown container mode '{variant}")
 
-            node_ref = Node(package, executable, name, namespace, remaps=component_remaps, output=output)
+            node_ref = Node(
+                package,
+                executable,
+                name,
+                namespace,
+                remaps=component_remaps,
+                output=output,
+            )
 
         if isinstance(node_ref, Composer):
             comp = node_ref

--- a/better_launch/utils/click.py
+++ b/better_launch/utils/click.py
@@ -1,5 +1,7 @@
 from typing import Any, Type, Iterable, Callable
+import json
 import os
+
 from dataclasses import dataclass
 import click
 
@@ -19,6 +21,7 @@ class DeclaredArg:
 @dataclass
 class Overrides:
     ui: bool = False
+    node_param_override: bool = False
     colormode = Colormode.DEFAULT
     screen_log_format: str = None
     file_log_format: str = None
@@ -26,12 +29,18 @@ class Overrides:
     def __init__(
         self,
         ui: bool = False,
+        node_param_override: bool = False,
         colormode: Colormode = Colormode.DEFAULT,
         screen_log_format: str = None,
         file_log_format: str = None,
     ):
         env_ui = os.environ.get("BL_UI_OVERRIDE", str(ui)).lower()
         self.ui = env_ui in ("enable", "true", "1")
+
+        env_node_param_override = os.environ.get(
+            "BL_NODE_PARAM_OVERRIDE", str(node_param_override)
+        ).lower()
+        self.node_param_override = env_node_param_override in ("enable", "true", "1")
 
         env_colormode = os.environ.get("BL_COLORMODE_OVERRIDE", colormode.name)
         self.colormode = Colormode[env_colormode.upper()]
@@ -68,11 +77,22 @@ def get_click_options(declared_args: Iterable[DeclaredArg]) -> list[click.Option
     return options
 
 
-def get_click_overrides(overrides: Overrides, expose: bool = False) -> list[click.Option]:
+def get_click_overrides(
+    overrides: Overrides, expose: bool = False
+) -> list[click.Option]:
     # Additional overrides for launch arguments
     def set_override_ui(ctx: click.Context, param: click.Parameter, value: str):
         if value != "unset":
             overrides.ui = value == "enable"
+        return value
+
+    def set_override_node_params(
+        ctx: click.Context, param: click.Parameter, value: str
+    ):
+        if value != "unset":
+            overrides.node_param_override = value == "enable"
+            if overrides.node_param_override:
+                ctx.allow_extra_args = True
         return value
 
     def set_override_colormode(ctx: click.Context, param: click.Parameter, value: str):
@@ -92,6 +112,17 @@ def get_click_overrides(overrides: Overrides, expose: bool = False) -> list[clic
             help="Override to enable/disable the terminal UI",
             expose_value=expose,  # not passed to our run method
             callback=set_override_ui,
+        ),
+        click.Option(
+            ["--bl_node_param_override"],
+            type=click.types.Choice(
+                ["enable", "disable", "unset"], case_sensitive=False
+            ),
+            show_choices=True,
+            default="unset",
+            help="Override to enable/disable node parameter overrides",
+            expose_value=expose,
+            callback=set_override_node_params,
         ),
         click.Option(
             ["--bl_colormode_override"],
@@ -116,11 +147,78 @@ def get_click_launch_command(
     allow_kwargs: bool = False,
 ) -> click.Command:
     click_cmd = click.Command(
-        cmd_name, callback=launch_func, params=options, help=cmd_help
+        cmd_name,
+        callback=launch_func,
+        params=options,
+        help=cmd_help,
+        context_settings={"ignore_unknown_options": True},
     )
-
-    if allow_kwargs:
-        click_cmd.allow_extra_args = True
-        click_cmd.ignore_unknown_options = True
+    click_cmd.allow_extra_args = allow_kwargs
+    click_cmd.ignore_unknown_options = True
 
     return click_cmd
+
+
+def args_to_dict(args: list[str]) -> dict[str, Any]:
+    """
+    Convert a list of CLI arguments to a dictionary.
+
+    Args:
+        args: List like ['--my_node.rate', '10', '--verbose', 'true']
+
+    Returns:
+        Dict like {'my_node.rate': 10, 'verbose': True}
+
+    Values are parsed as JSON if possible, otherwise kept as strings.
+    """
+    result = {}
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if not arg.startswith("-"):
+            raise ValueError("Extra argument keys must start with a dash")
+
+        if i + 1 >= len(args):
+            raise ValueError(
+                f"extra arguments need to be '--<key> <value>' tuples ({args})"
+            )
+
+        key = arg.lstrip("-")
+        value_str = args[i + 1]
+        try:
+            value = json.loads(value_str)
+        except (ValueError, json.JSONDecodeError):
+            value = value_str
+        result[key] = value
+        i += 2
+
+    return result
+
+
+def parse_node_params(
+    kwargs: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    """
+    Extract node.param keys from kwargs dict.
+
+    Args:
+        kwargs: Dict of CLI arguments (e.g., {'my_node.rate': 10, 'verbose': True})
+
+    Returns:
+        Tuple of (remaining_kwargs, node_params) where:
+        - remaining_kwargs: Kwargs that weren't node params
+        - node_params: Dict like {'my_node': {'rate': 10}}
+    """
+    remaining_kwargs = {}
+    node_params = {}
+
+    for key, value in kwargs.items():
+        if "." in key:
+            node_name, param_name = key.split(".", 1)
+            if node_name not in node_params:
+                node_params[node_name] = {}
+            node_params[node_name][param_name] = value
+        else:
+            remaining_kwargs[key] = value
+
+    return remaining_kwargs, node_params

--- a/better_launch/wrapper.py
+++ b/better_launch/wrapper.py
@@ -1,7 +1,9 @@
 from typing import Callable
-import os
-import platform
 from ast import literal_eval
+import os
+import sys
+import platform
+
 import signal
 import inspect
 import click
@@ -24,6 +26,8 @@ from better_launch.utils.click import (
     get_click_options,
     get_click_overrides,
     get_click_launch_command,
+    parse_node_params,
+    args_to_dict,
 )
 from better_launch.ros import logging as roslog
 
@@ -75,7 +79,7 @@ def launch_this(
     def decoration_helper(func):
         sig = inspect.signature(func)
         declared_args = _get_declared_args(sig, func.__doc__)
-        
+
         func_doc = doc.parse(func.__doc__)
 
         argspec = inspect.getfullargspec(func)
@@ -127,7 +131,9 @@ def _init_signal_handlers() -> None:
         signal.signal(signal.SIGQUIT, sigterm_handler)
 
 
-def _get_declared_args(signature: inspect.Signature, docstring: str = None) -> list[DeclaredArg]:
+def _get_declared_args(
+    signature: inspect.Signature, docstring: str = None
+) -> list[DeclaredArg]:
     # Extract more fine-grained information from the docstring
     param_docstrings = {}
     if docstring:
@@ -203,7 +209,11 @@ def _exec_launch_func(
         include_args: dict = glob[_bl_include_args]
         bl.logger.info(f"Including launch file: {includefile} (args={include_args})")
 
-        call_kw = {a.name: a.default for a in declared_args if a.default != DeclaredArg._undefined}
+        call_kw = {
+            a.name: a.default
+            for a in declared_args
+            if a.default != DeclaredArg._undefined
+        }
 
         for key, val in include_args.items():
             if allow_kwargs or key in call_kw:
@@ -275,31 +285,27 @@ def _exec_launch_func(
             overrides.colormode,
         )
 
-        if allow_kwargs is not None:
-            # If the launch func defines a **kwarg we can pass all extra arguments to it, with
-            # the caveat that these extra args need to be defined as `-[-]<key> val` tuples.
-            assert (
-                len(ctx.args) % 2 == 0
-            ), f"extra arguments need to be '--<key> <value>' tuples ({ctx.args})"
+        # Parse node-specific param overrides from ctx.args (extra unknown args)
+        # Convert ctx.args list to dict, then extract node params
+        extra_args_dict = args_to_dict(ctx.args)
+        remaining_kwargs, node_overrides = parse_node_params(extra_args_dict)
+        applied_overrides = node_overrides if overrides.node_param_override else {}
+        if applied_overrides:
+            BetterLaunch().set_node_param_overrides(applied_overrides)
 
-            for i in range(0, len(ctx.args), 2):
-                key = ctx.args[i]
-                if not key.startswith("-"):
-                    raise ValueError("Extra argument keys must start with a dash")
-
-                val = ctx.args[i + 1]
-                try:
-                    val = literal_eval(val)
-                except Exception:
-                    # Keep val as a string
-                    pass
-
-                kwargs[key.strip("-")] = val
+        if allow_kwargs and remaining_kwargs:
+            for key, value in remaining_kwargs.items():
+                if isinstance(value, str):
+                    try:
+                        value = literal_eval(value)
+                    except Exception:
+                        pass
+                kwargs[key] = value
 
         # By default BetterLaunch has access to all arguments from its launch function
         BetterLaunch._launch_func_args = dict(kwargs)
 
-        # Wrap the launch function so we can do some preparation and cleanup tasks. 
+        # Wrap the launch function so we can do some preparation and cleanup tasks.
         def launch_func_wrapper():
             try:
                 # Execute the launch function!
@@ -341,9 +347,8 @@ def _exec_launch_func(
         allow_kwargs=allow_kwargs,
     )
 
-    if allow_kwargs:
+    if allow_kwargs or overrides.node_param_override:
         click_cmd.allow_extra_args = True
-        click_cmd.ignore_unknown_options = True
 
     try:
         click_cmd.main(_argv)
@@ -352,7 +357,9 @@ def _exec_launch_func(
             raise
 
 
-def _expose_ros2_launch_function(launch_func: Callable, declared_args: list[DeclaredArg]):
+def _expose_ros2_launch_function(
+    launch_func: Callable, declared_args: list[DeclaredArg]
+):
     """Helper function that exposes a function decorated by launch_this so that it can be included by a regular ROS2 launch file. We achieve this by generating a `generate_launch_description` function and adding it to the module globals where the launch function is defined.
 
     Parameters

--- a/bin/bl
+++ b/bin/bl
@@ -158,6 +158,9 @@ class BetterLaunchPython(LaunchFile):
             if arg is not None:
                 args.extend([f"--{key}", arg])
 
+        # Pass through extra args (e.g., --node.param value for node overrides)
+        args.extend(ctx.args)
+
         # This does NOT return and will replace our executable with the new executable in the same process
         os.execvp("python3", [str(a) for a in args])
 
@@ -202,7 +205,7 @@ class BetterLaunchToml(LaunchFile):
         # Since the toml files are not executable, we need something else to run them. We
         # could create another script with a main function, but I don't think there's much
         # of a point to this.
-        launch_toml(self.filepath, launch_args=kwargs)
+        launch_toml(self.filepath, launch_args=kwargs, extra_args=ctx.args)
 
 
 class Ros2LaunchFile(LaunchFile):

--- a/examples/13_node_param_overrides.launch.py
+++ b/examples/13_node_param_overrides.launch.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Demonstrates CLI node parameter overrides.
+
+Node parameters can be overridden from the command line using dot-notation
+without needing to declare them explicitly in the launch function.
+
+Usage:
+    # Run with default parameters
+    bl better_launch 13_node_param_overrides.launch.py
+
+    # Enable node overrides and update talker's timer_period parameter
+    bl better_launch 13_node_param_overrides.launch.py \
+        --bl_node_param_override enable \
+        --my_talker.timer_period 2.0
+
+    # Override multiple node parameters
+    bl better_launch 13_node_param_overrides.launch.py \
+        --bl_node_param_override enable \
+        --my_talker.timer_period 0.1 \
+        --my_listener.some_param value
+
+The syntax is: --<node_name>.<param_name> <value>
+
+Values are automatically parsed as JSON when possible (numbers, booleans, lists, dicts).
+"""
+
+from better_launch import BetterLaunch, launch_this
+
+
+@launch_this
+def demo():
+    """
+    Demo launch file showing node parameter overrides from CLI.
+
+    Try running with:
+        bl better_launch 13_node_param_overrides.launch.py \
+            --bl_node_param_override enable \
+            --my_talker.timer_period 2.0
+    """
+    bl = BetterLaunch()
+
+    bl.node(
+        "examples_rclpy_minimal_publisher",
+        "publisher_local_function",
+        "my_talker",
+        params={"timer_period": 1.0},  # Can be overridden via --my_talker.timer_period
+    )
+
+    bl.node(
+        "examples_rclpy_minimal_subscriber",
+        "subscriber_member_function",
+        "my_listener",
+    )

--- a/tests/test_click_utils.py
+++ b/tests/test_click_utils.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Unit tests for click utilities, specifically parse_node_params."""
+
+import pytest
+from better_launch.utils.click import parse_node_params
+
+
+class TestParseNodeParams:
+    """Tests for parse_node_params function."""
+
+    def test_empty_kwargs(self):
+        """Empty kwargs should return empty results."""
+        remaining, node_params = parse_node_params({})
+        assert remaining == {}
+        assert node_params == {}
+
+    def test_no_node_params(self):
+        """Kwargs without dot notation should be returned as remaining."""
+        kwargs = {"verbose": True, "count": 5}
+        remaining, node_params = parse_node_params(kwargs)
+        assert remaining == {"verbose": True, "count": 5}
+        assert node_params == {}
+
+    def test_single_node_param(self):
+        """Single node.param should be extracted."""
+        kwargs = {"my_node.rate": 10}
+        remaining, node_params = parse_node_params(kwargs)
+        assert remaining == {}
+        assert node_params == {"my_node": {"rate": 10}}
+
+    def test_multiple_params_same_node(self):
+        """Multiple params for same node should be grouped."""
+        kwargs = {"talker.rate": 10, "talker.enabled": True}
+        remaining, node_params = parse_node_params(kwargs)
+        assert remaining == {}
+        assert node_params == {"talker": {"rate": 10, "enabled": True}}
+
+    def test_multiple_nodes(self):
+        """Params for different nodes should be separated."""
+        kwargs = {"talker.rate": 10, "listener.buffer_size": 100}
+        remaining, node_params = parse_node_params(kwargs)
+        assert remaining == {}
+        assert node_params == {
+            "talker": {"rate": 10},
+            "listener": {"buffer_size": 100},
+        }
+
+    def test_mixed_kwargs(self):
+        """Node params mixed with regular kwargs."""
+        kwargs = {"verbose": True, "my_node.rate": 10, "debug": False}
+        remaining, node_params = parse_node_params(kwargs)
+        assert remaining == {"verbose": True, "debug": False}
+        assert node_params == {"my_node": {"rate": 10}}
+
+    def test_string_value(self):
+        """String values should remain as strings."""
+        kwargs = {"node.name": "hello_world"}
+        remaining, node_params = parse_node_params(kwargs)
+        assert remaining == {}
+        assert node_params == {"node": {"name": "hello_world"}}
+
+    def test_float_value(self):
+        """Float values should be preserved."""
+        kwargs = {"node.rate": 0.5}
+        remaining, node_params = parse_node_params(kwargs)
+        assert remaining == {}
+        assert node_params == {"node": {"rate": 0.5}}
+
+    def test_boolean_values(self):
+        """Boolean values should be preserved."""
+        kwargs = {"node.enabled": True, "node.debug": False}
+        remaining, node_params = parse_node_params(kwargs)
+        assert remaining == {}
+        assert node_params == {"node": {"enabled": True, "debug": False}}
+
+    def test_list_value(self):
+        """List values should be preserved."""
+        kwargs = {"node.items": [1, 2, 3]}
+        remaining, node_params = parse_node_params(kwargs)
+        assert remaining == {}
+        assert node_params == {"node": {"items": [1, 2, 3]}}
+
+    def test_dict_value(self):
+        """Dict values should be preserved."""
+        kwargs = {"node.config": {"key": "value"}}
+        remaining, node_params = parse_node_params(kwargs)
+        assert remaining == {}
+        assert node_params == {"node": {"config": {"key": "value"}}}
+
+    def test_nested_param_name(self):
+        """Param names with dots should work (split on first dot only)."""
+        kwargs = {"node.nested.param": 42}
+        remaining, node_params = parse_node_params(kwargs)
+        assert remaining == {}
+        assert node_params == {"node": {"nested.param": 42}}
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
## Summary
This PR implements node parameter override feature request in #44

- add `--bl_node_param_override` (and `BL_NODE_PARAM_OVERRIDE`) to gate node param overrides
- pass through extra args for launches and apply overrides only when enabled

Tested locally and it works fine.