### PR TITLE
Fix on_exit not firing when a node exits cleanly

### DIFF
--- a/better_launch/elements/node.py
+++ b/better_launch/elements/node.py
@@ -310,8 +310,9 @@ class Node(AbstractNode, LiveParamsMixin):
                     if not line:  # EOF
                         break
                     q.put(line.rstrip("\n\r"))
-            except Exception:
-                # Signal error/EOF
+            finally:
+                # Signal EOF for both a clean stream close and an exception, so
+                # the watch loop can detect process exit and run on_exit.
                 q.put(None)
 
         def collect_bundle(q):


### PR DESCRIPTION
I noticed that the `on_exit` didn't seem to work when nodes crashed or i pkilled a specific node. This fix was found using Claude Opus 4.8. I haven't properly went through if this is `the` optimal fix but it seems to work. I primarily use on_exit to make all my nodes shut down if one shut downs (to easily see a crash).

read_stream only enqueued the EOF sentinel from its except branch, so a clean stream close (normal exit or an external kill) never decremented active_streams. The watch loop then never terminated and the node's on_exit callback was never invoked. Move the sentinel into a finally so it fires on both clean EOF and exceptions.

